### PR TITLE
add ability to select test service

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/maxScale: '1'
+        autoscaling.knative.dev/maxScale: "1"
     spec:
       containerConcurrency: 80
       timeoutSeconds: 300
@@ -62,6 +62,8 @@ docker build -t europe-west1-docker.pkg.dev/ivy-access/registry/bubble-go -f go/
 
 ### Executing the test
 
+Set the TEST_SERVICE value to rust/node/go to select the respective service.
+
 ```
-k6 run --vus 250 --duration 600s test.js
+k6 run -e TEST_SERVICE=<rust|node|go> --vus 250 --duration 600s test.js
 ```

--- a/test.js
+++ b/test.js
@@ -1,16 +1,32 @@
 import grpc from 'k6/net/grpc';
 import {check, sleep} from 'k6';
 
+const testService = __ENV.TEST_SERVICE;
+const availableServices = ['rust','node','go'];
+
+if (!testService) {
+  throw new Error('TEST_SERVICE environment variable not set.');
+}
+
+if (!availableServices.includes(testService)) {
+  throw new Error('Invalid TEST_SERVICE environment variable value.');
+}
+
 const client = new grpc.Client();
 client.load(['proto'], 'sort.proto');
 
 export default () => {
-  // client.connect('0.0.0.0:8000', {
-  //   plaintext: true,
-  // });
-  client.connect('bubble-rust-xmfhw3djgq-ew.a.run.app:443');
-  // client.connect('bubble-node-xmfhw3djgq-ew.a.run.app:443');
-  // client.connect('bubble-go-xmfhw3djgq-ew.a.run.app:443');
+  switch(testService) {
+    case 'rust':
+      client.connect('bubble-rust-xmfhw3djgq-ew.a.run.app:443');
+      break;
+    case 'node':
+      client.connect('bubble-node-xmfhw3djgq-ew.a.run.app:443');
+      break;
+    case 'go':
+      client.connect('bubble-go-xmfhw3djgq-ew.a.run.app:443');
+      break;
+  }
 
   const response = client.invoke('sort.v1.SortService/BubbleSort', {
     data: [


### PR DESCRIPTION
Related to [#1213](https://github.com/ivy-gmbh/ivy/issues/1213)

Adds the ability to select which test service to connect to, using the `TEST_SERVICE` env variable within the k6 CLI command.